### PR TITLE
Update strlib.c and strlib.h with UTF-8 support and additional functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ On Windows-based systems, run the compiled program by using the following comman
 | `matchAll()`          | Not Implementable   | Requires regex support                        | ❌             |
 | `replaceAll()`        | Not Implementable   | Requires regex or advanced manipulation       | ❌             |
 | `search()`            | Not Implementable   | Requires regex                                | ❌             |
-| `codePointAt()`       | Not Implementable   | Requires Unicode support                      | ❌             |
+| `codePointAt()`       | Not Implementable   | Requires Unicode support                      | ✅             |
 | `normalize()`         | Not Implementable   | Requires Unicode normalization                | ❌             |
 | `isWellFormed()`      | Not Implementable   | Requires Unicode support                      | ❌             |
 | `toWellFormed()`      | Not Implementable   | Requires Unicode support                      | ❌             |

--- a/strlib.c
+++ b/strlib.c
@@ -93,6 +93,17 @@ int str_isUnicodeWhitespace(int codePoint) {
 }
 
 // Checks if a character is a whitespace character
+int str_isWhitespace(const char* str) {
+    int codePoint = str_getUTF8CodePoint(&str);
+    // Check if the code point matches ASCII whitespace or Unicode whitespace
+    return (codePoint == 0x20 || // Space
+            codePoint == 0x09 || // Tab
+            codePoint == 0x0A || // Line Feed
+            codePoint == 0x0D || // Carriage Return
+            str_isUnicodeWhitespace(codePoint)); // Check Unicode whitespace
+}
+
+// Checks if a character is a whitespace character
 bool str_isValidUTF8(const char* str) {
     while (*str) {
         int seqLen = str_getUTF8CodePoint(&str);
@@ -103,7 +114,6 @@ bool str_isValidUTF8(const char* str) {
     return true;
 }
 
-// ==== HELPER FUNCTIONS FOR UTF-8 ====
 // Returns the length of the UTF-8 sequence starting with the given byte
 int str_getUTF8SequenceLength(unsigned char byte) {
     if (byte <= 0x7F) return 1; // ASCII

--- a/strlib.h
+++ b/strlib.h
@@ -1,18 +1,38 @@
 #ifndef STRLIB_H
 #define STRLIB_H
 
+#include <stdbool.h>
+
+// ==== HELPER FUNCTIONS ====
 // Copies characters from src to dest from start to end
 void str_copyRange(const char* src, int start, int end, char* dest);
 
 // Returns pointer to the first occurrence of substr in str after start position
 const char* str_find(const char* str, const char* substr, int start);
 
+const char* str_find(const char* str, const char* substr, int start);
+
 // Copies characters from src to dest until a specified string (delimiter) is found
 void str_copyUntil(const char* src, const char* delimiter, char* dest);
 
-// Checks if a character is a whitespace character
-int str_isWhitespace(char c);
+// Checks if a code point is a Unicode whitespace character
+int str_isUnicodeWhitespace(int codePoint);
 
+// Checks if a character is a whitespace character
+int str_isWhitespace(char* str);
+
+bool str_isValidUTF8(const char* str);
+
+// Returns the length of the UTF-8 sequence starting with the given byte
+int str_getUTF8SequenceLength(unsigned char byte);
+
+// Returns the code point from a sequence of UTF-8 bytes
+int str_getCodePointFromBytes(const char* str, int seqLen);
+
+// Returns the Unicode code point from the start of the string and advances the pointer
+int str_getUTF8CodePoint(const char** str);
+
+// ==== MAIN FUNCTIONS ====
 // Returns the length of a string
 int str_length(const char* str);
 

--- a/strlib.h
+++ b/strlib.h
@@ -3,24 +3,38 @@
 
 #include <stdbool.h>
 
+extern const int unicodeWhitespace[];
+
+// Error codes for the string library
+typedef enum {
+    STR_SUCCESS = 0,
+    STR_ERROR_NULL_INPUT,
+    STR_ERROR_INVALID_INDEX,
+    STR_ERROR_MEMORY_ALLOCATION,
+    STR_ERROR_INVALID_UTF8
+} StrError;
+
+extern StrError str_last_error;  // Holds the last error state
+
 // ==== HELPER FUNCTIONS ====
 // Copies characters from src to dest from start to end
-void str_copyRange(const char* src, int start, int end, char* dest);
+StrError str_copyRange(const char* src, int start, int end, char* dest);
 
 // Returns pointer to the first occurrence of substr in str after start position
 const char* str_find(const char* str, const char* substr, int start);
 
-const char* str_find(const char* str, const char* substr, int start);
+const char* str_findHelper(const char* str, const char* substr);
 
 // Copies characters from src to dest until a specified string (delimiter) is found
-void str_copyUntil(const char* src, const char* delimiter, char* dest);
+StrError str_copyUntil(const char* src, const char* delimiter, char* dest);
 
 // Checks if a code point is a Unicode whitespace character
 int str_isUnicodeWhitespace(int codePoint);
 
 // Checks if a character is a whitespace character
-int str_isWhitespace(char* str);
+int str_isWhitespace(const char* str);
 
+// Validates if a string is valid UTF-8
 bool str_isValidUTF8(const char* str);
 
 // Returns the length of the UTF-8 sequence starting with the given byte
@@ -33,13 +47,13 @@ int str_getCodePointFromBytes(const char* str, int seqLen);
 int str_getUTF8CodePoint(const char** str);
 
 // ==== MAIN FUNCTIONS ====
-// Returns the length of a string
+// Returns the length of a string (in Unicode code points)
 int str_length(const char* str);
 
 // Returns the character at a specific index in a string
-char str_charAt(const char* str, int index);
+char* str_charAt(const char* str, int index);
 
-// Returns the ASCII value of the character at a specific index in a string
+// Returns the ASCII/Unicode value of the character at a specific index in a string
 int str_charCodeAt(const char* str, int index);
 
 // Returns the index of the first occurrence of a substring in a string
@@ -48,26 +62,26 @@ int str_indexOf(const char* str, const char* substr);
 // Returns the index of the last occurrence of a substring in a string
 int str_lastIndexOf(const char* str, const char* substr);
 
-// Joins two strings together
-void str_concat(const char* str1, const char* str2, char* result);
+// Joins two strings together and stores the result in the result buffer
+StrError str_concat(const char* str1, const char* str2, char* result);
 
 // Converts the entire string to lowercase
-void str_toLowerCase(char* str);
+StrError str_toLowerCase(char* str);
 
 // Converts the entire string to uppercase
-void str_toUpperCase(char* str);
+StrError str_toUpperCase(char* str);
 
 // Removes leading whitespace from a string
-void str_trimStart(const char* str);
+StrError str_trimStart(char* str);
 
 // Removes trailing whitespace from a string
-void str_trimEnd(const char* str);
+StrError str_trimEnd(char* str);
 
 // Removes leading and trailing whitespace from a string
-void str_trim(const char* str);
+StrError str_trim(char* str);
 
-// Repeats a string a given number of times
-void str_repeat(const char* str, int count, char* result);
+// Repeats a string a given number of times and stores the result in the result buffer
+StrError str_repeat(const char* str, int count, char* result);
 
 // Checks if a string starts with a given prefix
 int str_startsWith(const char* str, const char* prefix);
@@ -75,22 +89,28 @@ int str_startsWith(const char* str, const char* prefix);
 // Checks if a string ends with a given suffix
 int str_endsWith(const char* str, const char* suffix);
 
-// Replaces all occurrences of a substring with another substring in a string
+// Extracts a substring from a string and stores it in the result buffer
 void str_slice(const char* str, int start, int end, char* result);
 
-// Extracts a substring from a string
-void str_substring(const char* str, int start, int end, char* result);
+// Extracts a substring from a string and stores it in the result buffer
+StrError str_substring(const char* str, int start, int end, char* result);
+
+// Returns the Unicode code point at a specific index in a string
+int str_codePointAt(const char* str, int index, int* codePoint);
+
+// Converts a Unicode code point to a string
+char* str_fromCodePoint(int codePoint);
 
 // Checks if a string includes a given substring
 int str_includes(const char* str, const char* substr);
 
-// Pad a string with a given character at the start to reach a target length
-void str_padStart(const char* str, int targetLength, const char* padStr, char* result);
+// Pads a string with a given character at the start to reach a target length
+StrError str_padStart(const char* str, int targetLength, const char* padStr, char* result, size_t resultSize);
 
-// Pad a string with a given character at the end to reach a target length
-void str_padEnd(const char* str, int targetLength, const char* padStr, char* result);
+// Pads a string with a given character at the end to reach a target length
+StrError str_padEnd(const char* str, int targetLength, const char* padStr, char* result, size_t resultSize);
 
-// Replace all occurrences of a substring with another substring in a string
-void str_replace(const char* str, const char* searchValue, const char* newValue, char* result);
+// Replaces all occurrences of a substring with another substring in a string
+StrError str_replace(const char* str, const char* searchValue, const char* newValue, char* result);
 
 #endif // STRLIB_H

--- a/strlib_test.c
+++ b/strlib_test.c
@@ -1,89 +1,213 @@
 #include <stdio.h>
 #include "strlib.h"
+#include <stdlib.h>
 
-int main() {
+
+void test_ascii_cases() {
+    // Test 1: ASCII-only string
     char str1[50] = "Hello, World!";
     char str2[] = "World";
     char result[100]; // Larger buffer for concatenated results
 
-    // Test str_length
+    printf("=== ASCII Tests ===\n");
+
+    // Test str_length with ASCII
     printf("Length of '%s': %d\n", str1, str_length(str1)); // Should print 13
 
-    // Test str_charAt
-    printf("Character at index 7: %c\n", str_charAt(str1, 7)); // Should print 'W'
+    // Test str_charAt with ASCII
+    char* charAt = str_charAt(str1, 7);
+    if (charAt) {
+        printf("Character at index 7: %s\n", charAt); // Should print 'W'
+        free(charAt);
+    }
 
-    // Test str_charCodeAt
+    // Test str_charCodeAt with ASCII
     printf("ASCII value at index 7: %d\n", str_charCodeAt(str1, 7)); // Should print 87 ('W')
 
-    // Test str_indexOf
+    // Test str_indexOf with ASCII
     printf("Index of 'World': %d\n", str_indexOf(str1, str2)); // Should print 7
 
-    // Test str_lastIndexOf
+    // Test str_lastIndexOf with ASCII
     char str3[] = "Hello, Hello, World!";
     printf("Last index of 'Hello' in '%s': %d\n", str3, str_lastIndexOf(str3, "Hello")); // Should print 7
 
-    // Test str_concat
+    // Test str_concat with ASCII
     str_concat(str1, str2, result);
     printf("Concatenation: %s\n", result); // Should print "Hello, World!World"
 
     // Reset str1 for further tests
     str_concat("Hello, World!", "", str1);
 
-    // Test str_toLowerCase
+    // Test str_toLowerCase with ASCII
     str_toLowerCase(str1);
     printf("Lowercase: %s\n", str1); // Should print "hello, world!"
 
-    // Test str_toUpperCase
+    // Test str_toUpperCase with ASCII
     str_toUpperCase(str1);
     printf("Uppercase: %s\n", str1); // Should print "HELLO, WORLD!"
 
-    // Test str_trimStart
+    // Test str_trimStart with ASCII
     char str4[] = "   Trim me!";
     str_trimStart(str4);
     printf("Trim start: '%s'\n", str4); // Should print "Trim me!"
 
-    // Test str_trimEnd
+    // Test str_trimEnd with ASCII
     char str5[] = "Trim me!   ";
     str_trimEnd(str5);
     printf("Trim end: '%s'\n", str5); // Should print "Trim me!"
 
-    // Test str_trim
+    // Test str_trim with ASCII
     char str6[] = "   Trim me!   ";
     str_trim(str6);
     printf("Trim both: '%s'\n", str6); // Should print "Trim me!"
 
-    // Test str_repeat
+    // Test str_repeat with ASCII
     str_repeat("Repeat", 3, result);
     printf("Repeat 3 times: %s\n", result); // Should print "RepeatRepeatRepeat"
 
-    // Test str_startsWith
+    // Test str_startsWith with ASCII
     printf("Starts with 'Hello': %d\n", str_startsWith("Hello, World!", "Hello")); // Should print 1 (true)
 
-    // Test str_endsWith
+    // Test str_endsWith with ASCII
     printf("Ends with 'World!': %d\n", str_endsWith("Hello, World!", "World!")); // Should print 1 (true)
 
-    // Test str_slice
+    // Test str_slice with ASCII
     str_slice("Hello, World!", 7, 12, result);
     printf("Slice from index 7 to 12: %s\n", result); // Should print "World"
 
-    // Test str_substring
-    str_substring("Hello, World!", 12, 7, result);
-    printf("Substring from index 12 to 7: %s\n", result); // Should print "World" (handles reversed indices)
+    // Test str_substring with ASCII
+    str_substring("Hello, World!", 7, 12, result);
+    printf("Substring from index 7 to 12: %s\n", result); // Should print "World"
 
-    // Test str_includes
+    // Test str_includes with ASCII
     printf("Includes 'World': %d\n", str_includes("Hello, World!", "World")); // Should print 1 (true)
 
-    // Test str_padStart
-    str_padStart("Pad", 10, " ", result);
+    // Test str_padStart with ASCII
+    str_padStart("Pad", 10, " ", result, sizeof(result));  // Pass a string " " and the result buffer size
     printf("Pad start to length 10: '%s'\n", result); // Should print "       Pad"
 
-    // Test str_padEnd
-    str_padEnd("Pad", 10, " ", result);
+    // Test str_padEnd with ASCII
+    str_padEnd("Pad", 10, " ", result, sizeof(result));  // Pass a string " " and the result buffer size
     printf("Pad end to length 10: '%s'\n", result); // Should print "Pad       "
 
-    // Test str_replace
+    // Test str_replace with ASCII
     str_replace("Hello, World!", "World", "Universe", result);
     printf("Replace 'World' with 'Universe': %s\n", result); // Should print "Hello, Universe!"
+}
+
+void test_utf8_cases() {
+    // Test 2: UTF-8 string (without emojis)
+    printf("\n=== UTF-8 Tests ===\n");
+
+    char result[100];  // Add this missing declaration
+
+    // Test str_length with UTF-8
+    char utf8Str[] = "Héllö, 世界!";
+    printf("Length of '%s' (UTF-8): %d\n", utf8Str, str_length(utf8Str)); // Should print 10
+
+    // Test str_charAt with UTF-8
+    char* charAt = str_charAt(utf8Str, 7);  // Add missing charAt declaration
+    if (charAt) {
+        printf("Character at index 7 (UTF-8): %s\n", charAt); // Should print '世'
+        free(charAt);
+    }
+
+    // Test str_charCodeAt with UTF-8
+    printf("Code point at index 7 (UTF-8): %d\n", str_charCodeAt(utf8Str, 7)); // Should print 19990 ('世')
+
+    // Test str_indexOf with UTF-8
+    printf("Index of '世界': %d\n", str_indexOf(utf8Str, "世界")); // Should print 7
+
+    // Test str_concat with UTF-8
+    str_concat(utf8Str, "World", result);
+    printf("UTF-8 Concatenation: %s\n", result); // Should print "Héllö, 世界!World"
+
+    // Test str_toLowerCase with UTF-8
+    char utf8Upper[] = "HÉLLÖ, 世界!";
+    str_toLowerCase(utf8Upper);
+    printf("UTF-8 Lowercase: %s\n", utf8Upper); // Should print "héllö, 世界!"
+
+    // Test str_toUpperCase with UTF-8
+    str_toUpperCase(utf8Str);
+    printf("UTF-8 Uppercase: %s\n", utf8Str); // Should print "HÉLLÖ, 世界!"
+
+    // Test str_slice with UTF-8
+    str_slice(utf8Str, 7, 9, result);
+    printf("UTF-8 Slice from index 7 to 9: %s\n", result); // Should print "世界"
+
+    // Test str_replace with UTF-8
+    str_replace(utf8Str, "世界", "Universe", result);
+    printf("Replace '世界' with 'Universe': %s\n", result); // Should print "Héllö, Universe!"
+
+    // UTF-8 whitespace tests
+    char utf8SpaceStr[] = " \u3000\u2002Héllö, 世界! \u2005\u3000 ";  // Contains regular spaces, em spaces, en spaces
+    printf("Original with UTF-8 spaces: '%s'\n", utf8SpaceStr);
+
+    // Test str_trimStart with UTF-8
+    str_trimStart(utf8SpaceStr);
+    printf("Trim UTF-8 start: '%s'\n", utf8SpaceStr); // Should print "Héllö, 世界! \u2005\u3000 "
+
+    // Reset string for trim end test
+    char utf8SpaceStrEnd[] = " \u3000\u2002Héllö, 世界! \u2005\u3000 ";  // Reset to original with spaces
+    str_trimEnd(utf8SpaceStrEnd);
+    printf("Trim UTF-8 end: '%s'\n", utf8SpaceStrEnd); // Should print " \u3000\u2002Héllö, 世界!"
+
+    // Reset string for trim both sides
+    char utf8SpaceStrBoth[] = " \u3000\u2002Héllö, 世界! \u2005\u3000 ";  // Reset to original with spaces
+    str_trim(utf8SpaceStrBoth);
+    printf("Trim UTF-8 both: '%s'\n", utf8SpaceStrBoth); // Should print "Héllö, 世界!"
+
+    // Test regular trimming on ASCII spaces
+    char asciiSpaceStr[] = "    Trim me!    ";
+    str_trim(asciiSpaceStr);
+    printf("Trim both (ASCII): '%s'\n", asciiSpaceStr); // Should print "Trim me!"
+}
+
+void test_utf8_with_emojis_cases() {
+    // Test 3: UTF-8 + Emojis
+    printf("\n=== UTF-8 + Emoji Tests ===\n");
+
+    char utf8EmojiStr[] = "Hello, 🌍🚀!";  // "🌍" and "🚀" are emojis
+    char result[100];  // Add missing declaration
+
+    // Test str_length with UTF-8 + Emojis
+    printf("Length of '%s' (UTF-8 + Emojis): %d\n", utf8EmojiStr, str_length(utf8EmojiStr)); // Should print 10 (counts Unicode code points)
+
+    // Test str_charAt with UTF-8 + Emojis
+    char* charAtEmoji = str_charAt(utf8EmojiStr, 7); // Position of the Earth emoji 🌍
+    if (charAtEmoji) {
+        printf("Character at index 7 (UTF-8 + Emojis): %s\n", charAtEmoji); // Should print "🌍"
+        free(charAtEmoji);
+    }
+
+    // Test str_charCodeAt with UTF-8 + Emojis
+    printf("Code point at index 7 (UTF-8 + Emojis): %d\n", str_charCodeAt(utf8EmojiStr, 7)); // Should print the code point for 🌍 (127757)
+
+    // Test str_indexOf with UTF-8 + Emojis
+    printf("Index of '🚀': %d\n", str_indexOf(utf8EmojiStr, "🚀")); // Should print 8 (index of the rocket emoji)
+
+    // Test str_replace with UTF-8 + Emojis
+    str_replace(utf8EmojiStr, "🚀", "🛸", result);  // Replacing the rocket emoji 🚀 with the UFO emoji 🛸
+    printf("Replace '🚀' with '🛸': %s\n", result); // Should print "Hello, 🌍🛸!"
+
+    // Test str_concat with UTF-8 + Emojis
+    char utf8EmojiStr2[] = " Goodbye, 🌙!";
+    str_concat(utf8EmojiStr, utf8EmojiStr2, result);
+    printf("UTF-8 + Emoji Concatenation: %s\n", result); // Should print "Hello, 🌍🚀! Goodbye, 🌙!"
+
+    // Test str_toLowerCase with UTF-8 + Emojis (emojis shouldn't be affected)
+    str_toLowerCase(utf8EmojiStr);
+    printf("Lowercase (UTF-8 + Emojis): %s\n", utf8EmojiStr); // Should print "hello, 🌍🚀!"
+
+    // Test str_toUpperCase with UTF-8 + Emojis (emojis shouldn't be affected)
+    str_toUpperCase(utf8EmojiStr);
+    printf("Uppercase (UTF-8 + Emojis): %s\n", utf8EmojiStr); // Should print "HELLO, 🌍🚀!"
+}
+
+int main() {
+    test_ascii_cases();
+    test_utf8_cases();
+    test_utf8_with_emojis_cases();
 
     return 0;
 }


### PR DESCRIPTION
This pull request includes updates to `strlib.c` and `strlib.h` to add support for UTF-8 encoding. The following changes have been made:

- The `str_copyRange` function now returns a `StrError` code to handle memory allocation errors.

- The `str_find` function has been updated to include a helper function `str_findHelper`.

- The `str_copyUntil` function now returns a `StrError` code to handle memory allocation errors.

- The `str_isWhitespace` function has been updated to accept a string instead of a character.

- The `str_isValidUTF8` function has been added to validate if a string is valid UTF-8.

- The `str_getUTF8SequenceLength` function has been added to get the length of a UTF-8 sequence.

- The `str_getCodePointFromBytes` function has been added to get the code point from a sequence of UTF-8 bytes.

- The `str_getUTF8CodePoint` function has been added to get the Unicode code point from a string.

- The `str_charAt` function now returns a pointer to the character instead of the character itself.

- The `str_toLowerCase` function now returns a `StrError` code to handle memory allocation errors.

- The `str_toUpperCase` function now returns a `StrError` code to handle memory allocation errors.

- The `str_trimStart` function now returns a `StrError` code to handle memory allocation errors.

- The `str_trimEnd` function now returns a `StrError` code to handle memory allocation errors.

- The `str_trim` function now returns a `StrError` code to handle memory allocation errors.

- The `str_repeat` function now returns a `StrError` code to handle memory allocation errors.

- The `str_substring` function now returns a `StrError` code to handle memory allocation errors.

- The `str_codePointAt` function has been added to get the Unicode code point at a specific index in a string.

- The `str_fromCodePoint` function has been added to convert a Unicode code point to a string.

- The `str_padStart` function now returns a `StrError` code to handle memory allocation errors.

- The `str_padEnd` function now returns a `StrError` code to handle memory allocation errors.

- The `str_replace` function now returns a `StrError` code to handle memory allocation errors.

These updates improve the functionality of the string library and provide better support for UTF-8 encoding.